### PR TITLE
[CI] Verify user permissions before checkout (test user)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,8 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
+        githubEnv()
+        githubPrCheckApproved()
         // Here we do a checkout into a temporary directory in order to have the
         // side-effect of setting up the git environment correctly.
         gitCheckout(basedir: "${pwd(tmp: true)}", githubNotifyFirstTimeContributor: true)


### PR DESCRIPTION
## Proposed commit message

Jenkinsfile: Check user permissions to execute pull requests before cloning a PR branch (Checkout). 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] When an external contributor proposes a PR checkout is not triggered
- [ ] When the PR is approved by a repo user with write permissions the CI pipeline is triggered

